### PR TITLE
fix: use portable shebang in emacs-mcp-stdio.sh

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,13 @@ mcp-server-lib.el NEWS -- history of user-visible changes
 
 ** Bug Fixes
 
+*** Use portable shebang in emacs-mcp-stdio.sh
+    Changed the shebang from ~#!/bin/bash~ to ~#!/usr/bin/env bash~ so the
+    stdio shim runs on systems where bash is not installed at ~/bin/bash~
+    (NixOS, Alpine, some BSDs, minimal containers). All platforms that
+    previously worked continue to work since ~/usr/bin/env~ is a POSIX
+    standard location.
+
 *** Fixed non-ASCII tool parameters arriving as unibyte strings
     When tool parameters containing non-ASCII characters (e.g. UTF-8) were
     received via the stdio transport, base64 decoding produced unibyte strings.

--- a/emacs-mcp-stdio.sh
+++ b/emacs-mcp-stdio.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # emacs-mcp-stdio.sh - Connect to Emacs MCP server via stdio transport
 #
 # Copyright (C) 2025 Laurynas Biveinis


### PR DESCRIPTION
## Summary

Change `emacs-mcp-stdio.sh`'s shebang from `#!/bin/bash` to `#!/usr/bin/env bash` so the stdio shim runs on systems where bash isn't at `/bin/bash`.

## Why

`#!/bin/bash` is a hard-coded absolute path that isn't universal:

- **NixOS** has bash at `/nix/store/.../bin/bash`; `/bin/bash` does not exist.
- **Alpine** and some minimal containers place bash at `/usr/bin/bash`.
- Same for some BSDs and any POSIX host without `/bin` as a symlink.

On every affected system the current shim fails at launch with:

```
/bin/bash: bad interpreter: No such file or directory
```

`#!/usr/bin/env bash` resolves bash via `PATH`, which works on every platform where the script already runs (since `/usr/bin/env` is a POSIX-standard location) **and** additionally on NixOS / Alpine / minimal containers.

## Why `env bash` and not `sh`

The script uses bashisms — `readonly`, arrays, `[[ ]]`, `${var#prefix}` parameter expansion — so env-resolving `bash` is the correct tool. Not changing to `sh`.

## Verification

Reproduced on NixOS 26.05 packaging this project via nixpkgs melpa-builder: before the change, invoking the shim from an `emacsWithPackages` wrapper failed with the `bad interpreter` error; after the change, `initialize` and `tools/list` dispatch normally over stdio.

No other change; no runtime behavior difference on Linux distros that already worked.

## NEWS

Added an entry under the `0.2.1 (unreleased)` Bug Fixes section.

## Test plan

- [x] Script dispatches JSON-RPC on NixOS (was broken, now works)
- [x] `bash -n emacs-mcp-stdio.sh` still parses cleanly
- [ ] Maintainer sanity-check on a stock Linux host (`/bin/bash` present) — no expected change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved script portability to support systems where Bash is installed in non-standard locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->